### PR TITLE
Continuous Integration: running Django tests in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+sudo: required
+language: minimal
+dist: xenial
+
+services:
+  - docker
+
+install:
+  - docker-compose pull
+  - docker-compose build
+
+script:
+  - |
+    docker-compose run -e DJANGO_SETTINGS_MODULE=backend.settings.testing \
+    --no-deps --rm backend python manage.py test


### PR DESCRIPTION
Builds are passing:
https://travis-ci.org/nokia-wroclaw/innovativeproject-inventory-of-supplies/builds/