### PR TITLE
RESTful inventory report and supply views

### DIFF
--- a/backend/backend/permissions.py
+++ b/backend/backend/permissions.py
@@ -1,6 +1,4 @@
 from rest_framework import permissions
-from .models import Supply
-
 
 class IsAuthenticatedReadOnly(permissions.BasePermission):
     def has_permission(self, request, view):

--- a/backend/inventories/models.py
+++ b/backend/inventories/models.py
@@ -2,6 +2,7 @@ from django.db import models
 from datetime import date as datetime_date
 from supplies.models import Supply
 
+
 class InventoryReport(models.Model):
     """
     InventoryReport holds one-to-many relationship with InventorySupply objects
@@ -19,7 +20,8 @@ class InventorySupply(models.Model):
         is_checked = True, the supply has been checkout out during reporting stage
         is_checked = False (default), the supply hasn't been checked out yet
     """
-    inventory_supply = models.ForeignKey(Supply, on_delete=models.CASCADE, blank=True, null=True)
+    inventory_supply = models.ForeignKey(
+        Supply, on_delete=models.CASCADE, blank=True, null=True)
     is_checked = models.BooleanField(default=False)
-    inventory_report = models.ForeignKey(InventoryReport, 
-        on_delete=models.CASCADE, related_name="inventory_supplies", blank=True, null=True)
+    inventory_report = models.ForeignKey(InventoryReport,
+                                         on_delete=models.CASCADE, related_name="inventory_supplies", blank=True, null=True)

--- a/backend/inventories/serializers.py
+++ b/backend/inventories/serializers.py
@@ -10,7 +10,7 @@ class InventorySupplySerializer(serializers.ModelSerializer):
 
     class Meta:
         model = InventorySupply
-        fields = ('id','supply', 'is_checked')
+        fields = ('supply', 'is_checked')
 
 
 class InventorySupplyHeaderSerializer(serializers.ModelSerializer):

--- a/backend/inventories/serializers.py
+++ b/backend/inventories/serializers.py
@@ -27,7 +27,7 @@ class InventorySupplyHeaderSerializer(serializers.ModelSerializer):
         fields = ('id', 'supply_header', 'is_checked')
 
 
-class InventoryReportListSerializer(serializers.ModelSerializer):
+class InventoryReportSerializer(serializers.ModelSerializer):
     """
     Serializer for the purpose of listing all InventoryReport objects
     It doesn't contain details about it's supplies, and provides only representational form
@@ -45,19 +45,6 @@ class InventoryReportListSerializer(serializers.ModelSerializer):
     def get_supplies_checked_out(self, obj):
         return obj.inventory_supplies.all().exclude(is_checked=False).count()
 
-
-
-class InventoryReportSerializer(serializers.ModelSerializer):
-    supplies = InventorySupplyHeaderSerializer(source='inventory_supplies', many=True, read_only=True)
-
-    class Meta:
-        model = InventoryReport
-        fields = ('id', 'date', 'name', 'supplies',)
-        extra_kwargs = {
-            'supplies': {'required': False},
-            'date': {'required': False},
-        }
-
     def create(self, validated_data, **kwargs):
         """
         Automatically populates with InventorySupply
@@ -68,5 +55,6 @@ class InventoryReportSerializer(serializers.ModelSerializer):
             inventory_supply.save()
         report.save()
         return report
+
 
 

--- a/backend/inventories/tests.py
+++ b/backend/inventories/tests.py
@@ -371,7 +371,7 @@ class InventorySupplyTest(APITestCase):
         request = self.factory.get(url)
         force_authenticate(request, user=self.test_admin)
         response = InventorySupplyView.as_view()(
-            request, supply_id=self.test_supply.id, inventory_id=self.test_report.id)
+            request, inventory_supply_id=self.test_supply.id, inventory_id=self.test_report.id)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data['supply']['name'], self.test_supply_name)
@@ -384,7 +384,7 @@ class InventorySupplyTest(APITestCase):
         request = self.factory.get(url)
         force_authenticate(request, user=self.test_user)
         response = InventorySupplyView.as_view()(
-            request, supply_id=self.test_supply.id, inventory_id=self.test_report.id)
+            request, inventory_supply_id=self.test_supply.id, inventory_id=self.test_report.id)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data['supply']['name'], self.test_supply_name)
@@ -397,7 +397,7 @@ class InventorySupplyTest(APITestCase):
         url = reverse("inventories:supplies-details-update", args=[self.test_report.id, self.test_supply.id])
         request = self.factory.get(url)
         response = InventorySupplyView.as_view()(
-            request, supply_id=self.test_supply.id, inventory_id=self.test_report.id)
+            request, inventory_supply_id=self.test_supply.id, inventory_id=self.test_report.id)
 
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
@@ -405,12 +405,12 @@ class InventorySupplyTest(APITestCase):
         """
         Test incorrectly checking non-existing inventory supply while authorized
         """
-        invalid_test_supply_id = 153
-        url = reverse("inventories:supplies-details-update", args=[self.test_report.id, invalid_test_supply_id])
+        invalid_test_inventory_supply_id = 153
+        url = reverse("inventories:supplies-details-update", args=[self.test_report.id, invalid_test_inventory_supply_id])
         request = self.factory.get(url)
         force_authenticate(request, user=self.test_user)
         response = InventorySupplyView.as_view()(
-            request, supply_id=invalid_test_supply_id, inventory_id=self.test_report.id)
+            request, inventory_supply_id=invalid_test_inventory_supply_id, inventory_id=self.test_report.id)
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
@@ -425,7 +425,7 @@ class InventorySupplyTest(APITestCase):
         request = self.factory.patch(url, {'is_checked': True})
         force_authenticate(request, user=self.test_admin)
         response = InventorySupplyView.as_view()(
-            request, supply_id=self.test_inventory_supply.id, inventory_id=self.test_report.id)
+            request, inventory_supply_id=self.test_inventory_supply.id, inventory_id=self.test_report.id)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         is_checked = InventorySupply.objects.get(pk=self.test_inventory_supply.id).is_checked
@@ -442,7 +442,7 @@ class InventorySupplyTest(APITestCase):
         request = self.factory.patch(url, {'is_checked': True})
         force_authenticate(request, user=self.test_user)
         response = InventorySupplyView.as_view()(
-            request, supply_id=self.test_supply.id, inventory_id=self.test_report.id)
+            request, inventory_supply_id=self.test_supply.id, inventory_id=self.test_report.id)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         is_checked = InventorySupply.objects.get(pk=self.test_inventory_supply.id).is_checked
@@ -458,7 +458,7 @@ class InventorySupplyTest(APITestCase):
         url = reverse("inventories:supplies-details-update", args=[self.test_report.id, self.test_supply.id])
         request = self.factory.patch(url, {'is_checked': True})
         response = InventorySupplyView.as_view()(
-            request, supply_id=self.test_supply.id, inventory_id=self.test_report.id)
+            request, inventory_supply_id=self.test_supply.id, inventory_id=self.test_report.id)
 
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
         is_checked = InventorySupply.objects.get(pk=self.test_inventory_supply.id).is_checked
@@ -468,11 +468,11 @@ class InventorySupplyTest(APITestCase):
         """
         Test incorrectly setting non-existing inventory supply's "is_checked" status to true
         """
-        invalid_test_supply_id = 153
-        url = reverse("inventories:supplies-details-update", args=[invalid_test_supply_id, self.test_supply.id])
+        invalid_test_inventory_supply_id = 153
+        url = reverse("inventories:supplies-details-update", args=[invalid_test_inventory_supply_id, self.test_supply.id])
         request = self.factory.patch(url, {'is_checked': True})
         force_authenticate(request, user=self.test_user)
         response = InventorySupplyView.as_view()(
-            request, supply_id=invalid_test_supply_id, inventory_id=self.test_report.id)
+            request, inventory_supply_id=invalid_test_inventory_supply_id, inventory_id=self.test_report.id)
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)

--- a/backend/inventories/tests.py
+++ b/backend/inventories/tests.py
@@ -6,8 +6,8 @@ from django.urls import reverse
 from .models import InventoryReport, InventorySupply
 from users.models import User
 from supplies.models import Supply
-from .views import InventoryReportCreateView, InventoryReportListView, InventoryReportDetailsView, InventoryReportRemoveView
-from .views import InventorySupplyDetailsUpdateView
+from .views import InventoryReportListCreateView, InventoryReportDetailsView, InventoryReportRemoveView
+from .views import InventorySupplyView
 
 class InventoryReportCreateTests(APITestCase):
 
@@ -37,9 +37,9 @@ class InventoryReportCreateTests(APITestCase):
         """
 
         request = self.factory.post(
-            '/api/inventories/create', {'name': self.report_name})
+            '/api/inventories/', {'name': self.report_name})
         force_authenticate(request, user=self.test_admin)
-        response = InventoryReportCreateView.as_view()(request)
+        response = InventoryReportListCreateView.as_view()(request)
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         try:
@@ -55,9 +55,9 @@ class InventoryReportCreateTests(APITestCase):
         Required name parameter is not given
         """
         request = self.factory.post(
-            '/api/inventories/create', {})
+            '/api/inventories/', {})
         force_authenticate(request, user=self.test_admin)
-        response = InventoryReportCreateView.as_view()(request)
+        response = InventoryReportListCreateView.as_view()(request)
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(len(InventoryReport.objects.all()), 0)
@@ -68,9 +68,9 @@ class InventoryReportCreateTests(APITestCase):
         Report name is given as a parameter
         """
         request = self.factory.post(
-            '/api/inventories/create', {'name': self.report_name})
+            '/api/inventories/', {'name': self.report_name})
         force_authenticate(request, user=self.test_user)
-        response = InventoryReportCreateView.as_view()(request)
+        response = InventoryReportListCreateView.as_view()(request)
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         self.assertEqual(len(InventoryReport.objects.all()), 0)
@@ -82,9 +82,9 @@ class InventoryReportCreateTests(APITestCase):
         Authorization check is performed firstly, therefore 'forbidden' response should be returned
         """
         request = self.factory.post(
-            '/api/inventories/create', {})
+            '/api/inventories/', {})
         force_authenticate(request, user=self.test_user)
-        response = InventoryReportCreateView.as_view()(request)
+        response = InventoryReportListCreateView.as_view()(request)
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         self.assertEqual(len(InventoryReport.objects.all()), 0)
@@ -96,8 +96,8 @@ class InventoryReportCreateTests(APITestCase):
         Required name parameter is given
         """
         request = self.factory.post(
-            '/api/inventories/create', {'name': self.report_name})
-        response = InventoryReportCreateView.as_view()(request)
+            '/api/inventories/', {'name': self.report_name})
+        response = InventoryReportListCreateView.as_view()(request)
 
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
         self.assertEqual(len(InventoryReport.objects.all()), 0)
@@ -110,8 +110,8 @@ class InventoryReportCreateTests(APITestCase):
         Authorization check is performed firstly, therefore 'unauthorized' response should be returned
         """
         request = self.factory.post(
-            '/api/inventories/create', {})
-        response = InventoryReportCreateView.as_view()(request)
+            '/api/inventories/', {})
+        response = InventoryReportListCreateView.as_view()(request)
 
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
         self.assertEqual(len(InventoryReport.objects.all()), 0)
@@ -141,9 +141,9 @@ class InventoryReportListTests(APITestCase):
         # Report has to be generated through view to make sure it's populated with supplies
         cls.test_report_name = 'Test report'
         request = cls.factory.post(
-            '/api/inventories/create', {'name': cls.test_report_name})
+            '/api/inventories/', {'name': cls.test_report_name})
         force_authenticate(request, user=cls.test_admin)
-        InventoryReportCreateView.as_view()(request)
+        InventoryReportListCreateView.as_view()(request)
 
     def test_list_reports_admin(self):
         """
@@ -152,7 +152,7 @@ class InventoryReportListTests(APITestCase):
         request = self.factory.get(
             '/api/inventories')
         force_authenticate(request, user=self.test_admin)
-        response = InventoryReportListView.as_view()(request)
+        response = InventoryReportListCreateView.as_view()(request)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertTrue(len(response.data) > 0)
@@ -164,7 +164,7 @@ class InventoryReportListTests(APITestCase):
         request = self.factory.get(
             '/api/inventories')
         force_authenticate(request, user=self.test_user)
-        response = InventoryReportListView.as_view()(request)
+        response = InventoryReportListCreateView.as_view()(request)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertTrue(len(response.data) > 0)
@@ -175,7 +175,7 @@ class InventoryReportListTests(APITestCase):
         """
         request = self.factory.get(
             '/api/inventories')
-        response = InventoryReportListView.as_view()(request)
+        response = InventoryReportListCreateView.as_view()(request)
 
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
@@ -204,9 +204,9 @@ class InventoryReportDetailsTest(APITestCase):
         # Report has to be generated through view to make sure it's populated with supplies
         cls.test_report_name = 'Test report'
         request = cls.factory.post(
-            '/api/inventories/create', {'name': cls.test_report_name})
+            '/api/inventories/', {'name': cls.test_report_name})
         force_authenticate(request, user=cls.test_admin)
-        InventoryReportCreateView.as_view()(request)
+        InventoryReportListCreateView.as_view()(request)
         cls.test_report = InventoryReport.objects.get(name=cls.test_report_name)
 
     def test_report_details_admin(self):
@@ -279,9 +279,9 @@ class InventoryReportRemovalTest(APITestCase):
         # Report has to be generated through view to make sure it's populated with supplies
         cls.test_report_name = 'Test report'
         request = cls.factory.post(
-            '/api/inventories/create', {'name': cls.test_report_name})
+            '/api/inventories/', {'name': cls.test_report_name})
         force_authenticate(request, user=cls.test_admin)
-        InventoryReportCreateView.as_view()(request)
+        InventoryReportListCreateView.as_view()(request)
         cls.test_report = InventoryReport.objects.get(name=cls.test_report_name)
 
     def test_remove_report_admin(self):
@@ -356,17 +356,22 @@ class InventorySupplyTest(APITestCase):
             description=cls.test_supply_description)
         cls.test_supply.save()
 
-        cls.test_inventory_supply = InventorySupply(inventory_supply=cls.test_supply)
+        cls.test_report = InventoryReport(name=cls.report_name)
+        cls.test_report.save()
+
+        cls.test_inventory_supply = InventorySupply(inventory_supply=cls.test_supply, 
+            inventory_report=cls.test_report)
         cls.test_inventory_supply.save()
 
     def test_supply_details_admin(self):
         """
         Test correctly checking existing inventory supply details with admin account
         """
-        url = reverse("inventories:supplies-details-update", args=[self.test_supply.id])
+        url = reverse("inventories:supplies-details-update", args=[self.test_report.id, self.test_supply.id])
         request = self.factory.get(url)
         force_authenticate(request, user=self.test_admin)
-        response = InventorySupplyDetailsUpdateView.as_view()(request, pk=self.test_supply.id)
+        response = InventorySupplyView.as_view()(
+            request, supply_id=self.test_supply.id, inventory_id=self.test_report.id)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data['supply']['name'], self.test_supply_name)
@@ -375,10 +380,11 @@ class InventorySupplyTest(APITestCase):
         """
         Test correctly checking existing inventory supply details with user account
         """
-        url = reverse("inventories:supplies-details-update", args=[self.test_supply.id])
+        url = reverse("inventories:supplies-details-update", args=[self.test_report.id, self.test_supply.id])
         request = self.factory.get(url)
         force_authenticate(request, user=self.test_user)
-        response = InventorySupplyDetailsUpdateView.as_view()(request, pk=self.test_supply.id)
+        response = InventorySupplyView.as_view()(
+            request, supply_id=self.test_supply.id, inventory_id=self.test_report.id)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data['supply']['name'], self.test_supply_name)
@@ -388,9 +394,10 @@ class InventorySupplyTest(APITestCase):
         """
         Test correctly checking existing inventory supply details with user account
         """
-        url = reverse("inventories:supplies-details-update", args=[self.test_supply.id])
+        url = reverse("inventories:supplies-details-update", args=[self.test_report.id, self.test_supply.id])
         request = self.factory.get(url)
-        response = InventorySupplyDetailsUpdateView.as_view()(request, pk=self.test_supply.id)
+        response = InventorySupplyView.as_view()(
+            request, supply_id=self.test_supply.id, inventory_id=self.test_report.id)
 
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
@@ -399,10 +406,11 @@ class InventorySupplyTest(APITestCase):
         Test incorrectly checking non-existing inventory supply while authorized
         """
         invalid_test_supply_id = 153
-        url = reverse("inventories:supplies-details-update", args=[invalid_test_supply_id])
+        url = reverse("inventories:supplies-details-update", args=[self.test_report.id, invalid_test_supply_id])
         request = self.factory.get(url)
         force_authenticate(request, user=self.test_user)
-        response = InventorySupplyDetailsUpdateView.as_view()(request, pk=invalid_test_supply_id)
+        response = InventorySupplyView.as_view()(
+            request, supply_id=invalid_test_supply_id, inventory_id=self.test_report.id)
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
@@ -411,15 +419,16 @@ class InventorySupplyTest(APITestCase):
         Test correctly setting existing inventory supply's  "is_checked" status to true
         Admin privileges are used
         """
-        is_checked = InventorySupply.objects.get(pk=self.test_supply.id).is_checked
+        is_checked = InventorySupply.objects.get(pk=self.test_inventory_supply.id).is_checked
         self.assertFalse(is_checked)
-        url = reverse("inventories:supplies-details-update", args=[self.test_supply.id])
+        url = reverse("inventories:supplies-details-update", args=[self.test_report.id, self.test_supply.id])
         request = self.factory.patch(url, {'is_checked': True})
         force_authenticate(request, user=self.test_admin)
-        response = InventorySupplyDetailsUpdateView.as_view()(request, pk=self.test_supply.id)
+        response = InventorySupplyView.as_view()(
+            request, supply_id=self.test_inventory_supply.id, inventory_id=self.test_report.id)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        is_checked = InventorySupply.objects.get(pk=self.test_supply.id).is_checked
+        is_checked = InventorySupply.objects.get(pk=self.test_inventory_supply.id).is_checked
         self.assertTrue(is_checked)
 
     def test_update_supply_user(self):
@@ -427,15 +436,16 @@ class InventorySupplyTest(APITestCase):
         Test correctly setting existing inventory supply's  "is_checked" status to true
         User privileges are used
         """
-        is_checked = InventorySupply.objects.get(pk=self.test_supply.id).is_checked
+        is_checked = InventorySupply.objects.get(pk=self.test_inventory_supply.id).is_checked
         self.assertFalse(is_checked)
-        url = reverse("inventories:supplies-details-update", args=[self.test_supply.id])
+        url = reverse("inventories:supplies-details-update", args=[self.test_report.id, self.test_supply.id])
         request = self.factory.patch(url, {'is_checked': True})
         force_authenticate(request, user=self.test_user)
-        response = InventorySupplyDetailsUpdateView.as_view()(request, pk=self.test_supply.id)
+        response = InventorySupplyView.as_view()(
+            request, supply_id=self.test_supply.id, inventory_id=self.test_report.id)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        is_checked = InventorySupply.objects.get(pk=self.test_supply.id).is_checked
+        is_checked = InventorySupply.objects.get(pk=self.test_inventory_supply.id).is_checked
         self.assertTrue(is_checked)
 
     def test_update_supply_unauthorized(self):
@@ -443,14 +453,15 @@ class InventorySupplyTest(APITestCase):
         Test incorrectly setting existing inventory supply's  "is_checked" status to true
         User in unauthorized
         """
-        is_checked = InventorySupply.objects.get(pk=self.test_supply.id).is_checked
+        is_checked = InventorySupply.objects.get(pk=self.test_inventory_supply.id).is_checked
         self.assertFalse(is_checked)
-        url = reverse("inventories:supplies-details-update", args=[self.test_supply.id])
+        url = reverse("inventories:supplies-details-update", args=[self.test_report.id, self.test_supply.id])
         request = self.factory.patch(url, {'is_checked': True})
-        response = InventorySupplyDetailsUpdateView.as_view()(request, pk=self.test_supply.id)
+        response = InventorySupplyView.as_view()(
+            request, supply_id=self.test_supply.id, inventory_id=self.test_report.id)
 
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
-        is_checked = InventorySupply.objects.get(pk=self.test_supply.id).is_checked
+        is_checked = InventorySupply.objects.get(pk=self.test_inventory_supply.id).is_checked
         self.assertFalse(is_checked)
 
     def test_update_invalid_supply(self):
@@ -458,9 +469,10 @@ class InventorySupplyTest(APITestCase):
         Test incorrectly setting non-existing inventory supply's "is_checked" status to true
         """
         invalid_test_supply_id = 153
-        url = reverse("inventories:supplies-details-update", args=[invalid_test_supply_id])
+        url = reverse("inventories:supplies-details-update", args=[invalid_test_supply_id, self.test_supply.id])
         request = self.factory.patch(url, {'is_checked': True})
         force_authenticate(request, user=self.test_user)
-        response = InventorySupplyDetailsUpdateView.as_view()(request, pk=invalid_test_supply_id)
+        response = InventorySupplyView.as_view()(
+            request, supply_id=invalid_test_supply_id, inventory_id=self.test_report.id)
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)

--- a/backend/inventories/urls.py
+++ b/backend/inventories/urls.py
@@ -1,13 +1,12 @@
 from django.urls import path
-from .views import InventoryReportListView, InventoryReportCreateView, InventoryReportDetailsView, InventoryReportRemoveView, InventorySupplyDetailsUpdateView
-
+from .views import InventoryReportListCreateView, InventoryReportDetailsView, InventoryReportRemoveView
+from .views import InventorySupplyView
 
 app_name = "inventories"
 
 urlpatterns = [
-    path('', InventoryReportListView.as_view()),
+    path('', InventoryReportListCreateView.as_view()),
     path('<int:pk>', InventoryReportDetailsView.as_view(), name='report-details'),
-    path('create', InventoryReportCreateView.as_view()),
+    path('<int:inventory_id>/supplies/<int:supply_id>', InventorySupplyView.as_view(), name='supplies-details-update'),
     path('remove/<int:pk>', InventoryReportRemoveView.as_view(), name='report-remove'),
-    path('supplies/<int:pk>', InventorySupplyDetailsUpdateView.as_view(), name='supplies-details-update'), 
 ]

--- a/backend/inventories/urls.py
+++ b/backend/inventories/urls.py
@@ -7,6 +7,7 @@ app_name = "inventories"
 urlpatterns = [
     path('', InventoryReportListCreateView.as_view()),
     path('<int:pk>', InventoryReportDetailsView.as_view(), name='report-details'),
-    path('<int:inventory_id>/supplies/<int:supply_id>', InventorySupplyView.as_view(), name='supplies-details-update'),
+    path('<int:inventory_id>/supplies/<int:inventory_supply_id>',
+         InventorySupplyView.as_view(), name='supplies-details-update'),
     path('remove/<int:pk>', InventoryReportRemoveView.as_view(), name='report-remove'),
 ]

--- a/backend/inventories/validators.py
+++ b/backend/inventories/validators.py
@@ -1,0 +1,21 @@
+from .models import InventoryReport, InventorySupply
+
+class ParameterException(Exception):
+    pass
+
+def validate_input_data(kwargs):
+        if 'inventory_id' not in kwargs:
+            raise ParameterException({'message': 'Parameter "inventory_id" expected'})
+        if 'supply_id' not in kwargs:
+            raise ParameterException({'message': 'Parameter "supply_id" expected'})
+
+        try:
+            report = InventoryReport.objects.get(pk=kwargs.get('inventory_id'))
+            supply = InventorySupply.objects.get(pk=kwargs.get('supply_id'))
+
+            if supply not in report.inventory_supplies.all():
+                raise ParameterException({'message': 'No such supply in this inventory'})
+        except InventoryReport.DoesNotExist:
+            raise
+        except InventorySupply.DoesNotExist:
+            raise

--- a/backend/inventories/validators.py
+++ b/backend/inventories/validators.py
@@ -1,20 +1,26 @@
 from .models import InventoryReport, InventorySupply
 
+
 class ParameterException(Exception):
     pass
 
+
 def validate_input_data(kwargs):
     if 'inventory_id' not in kwargs:
-        raise ParameterException({'message': 'Parameter "inventory_id" expected'})
-    if 'supply_id' not in kwargs:
-        raise ParameterException({'message': 'Parameter "supply_id" expected'})
+        raise ParameterException(
+            {'message': 'Parameter "inventory_id" expected'})
+    if 'inventory_supply_id' not in kwargs:
+        raise ParameterException(
+            {'message': 'Parameter "inventory_supply_id" expected'})
 
     try:
         report = InventoryReport.objects.get(pk=kwargs.get('inventory_id'))
-        supply = InventorySupply.objects.get(pk=kwargs.get('supply_id'))
+        supply = report.inventory_supplies.get(
+            inventory_supply_id=kwargs.get('inventory_supply_id'))
 
         if supply not in report.inventory_supplies.all():
-            raise ParameterException({'message': 'No such supply in this inventory'})
+            raise ParameterException(
+                {'message': 'No such supply in this inventory'})
     except InventoryReport.DoesNotExist:
         raise
     except InventorySupply.DoesNotExist:

--- a/backend/inventories/validators.py
+++ b/backend/inventories/validators.py
@@ -4,18 +4,18 @@ class ParameterException(Exception):
     pass
 
 def validate_input_data(kwargs):
-        if 'inventory_id' not in kwargs:
-            raise ParameterException({'message': 'Parameter "inventory_id" expected'})
-        if 'supply_id' not in kwargs:
-            raise ParameterException({'message': 'Parameter "supply_id" expected'})
+    if 'inventory_id' not in kwargs:
+        raise ParameterException({'message': 'Parameter "inventory_id" expected'})
+    if 'supply_id' not in kwargs:
+        raise ParameterException({'message': 'Parameter "supply_id" expected'})
 
-        try:
-            report = InventoryReport.objects.get(pk=kwargs.get('inventory_id'))
-            supply = InventorySupply.objects.get(pk=kwargs.get('supply_id'))
+    try:
+        report = InventoryReport.objects.get(pk=kwargs.get('inventory_id'))
+        supply = InventorySupply.objects.get(pk=kwargs.get('supply_id'))
 
-            if supply not in report.inventory_supplies.all():
-                raise ParameterException({'message': 'No such supply in this inventory'})
-        except InventoryReport.DoesNotExist:
-            raise
-        except InventorySupply.DoesNotExist:
-            raise
+        if supply not in report.inventory_supplies.all():
+            raise ParameterException({'message': 'No such supply in this inventory'})
+    except InventoryReport.DoesNotExist:
+        raise
+    except InventorySupply.DoesNotExist:
+        raise

--- a/backend/inventories/views.py
+++ b/backend/inventories/views.py
@@ -9,6 +9,7 @@ from backend.pagination import ResultSetPagination
 from backend.permissions import IsAuthenticatedReadOnly
 from .validators import ParameterException, validate_input_data
 
+
 class InventoryReportListCreateView(generics.ListCreateAPIView):
     permission_classes = (IsAuthenticatedReadOnly | permissions.IsAdminUser,)
     queryset = InventoryReport.objects.all()
@@ -49,7 +50,7 @@ class InventoryReportRemoveView(generics.DestroyAPIView):
 class InventorySupplyView(generics.RetrieveUpdateAPIView):
     serializer_class = InventorySupplySerializer
     permission_classes = (permissions.IsAuthenticated,)
-    lookup_url_kwarg = 'supply_id'
+    lookup_field = 'inventory_supply_id'
 
     def get(self, request, *args, **kwargs):
         try:
@@ -61,7 +62,7 @@ class InventorySupplyView(generics.RetrieveUpdateAPIView):
             return Response('Report does not exist', status=status.HTTP_404_NOT_FOUND)
         except InventorySupply.DoesNotExist:
             return Response('Supply does not exist', status=status.HTTP_404_NOT_FOUND)
-    
+
     def patch(self, request, *args, **kwargs):
         try:
             validate_input_data(kwargs)
@@ -72,7 +73,7 @@ class InventorySupplyView(generics.RetrieveUpdateAPIView):
             return Response('Report does not exist', status=status.HTTP_404_NOT_FOUND)
         except InventorySupply.DoesNotExist:
             return Response('Supply does not exist', status=status.HTTP_404_NOT_FOUND)
-    
+
     def put(self, request, *args, **kwargs):
         try:
             validate_input_data(kwargs)
@@ -85,4 +86,4 @@ class InventorySupplyView(generics.RetrieveUpdateAPIView):
             return Response('Supply does not exist', status=status.HTTP_404_NOT_FOUND)
 
     def get_queryset(self):
-        return InventorySupply.objects.filter(pk=self.kwargs.get('supply_id'))
+        return InventorySupply.objects.filter(inventory_report_id=self.kwargs.get('inventory_id'))

--- a/backend/inventories/views.py
+++ b/backend/inventories/views.py
@@ -4,20 +4,15 @@ from rest_framework.response import Response
 from rest_framework.exceptions import NotFound
 
 from .models import InventoryReport, InventorySupply
-from .serializers import InventoryReportSerializer, InventorySupplySerializer, InventoryReportListSerializer
+from .serializers import InventoryReportSerializer, InventorySupplySerializer
 from backend.pagination import ResultSetPagination
+from backend.permissions import IsAuthenticatedReadOnly
+from .validators import ParameterException, validate_input_data
 
-
-class InventoryReportCreateView(generics.CreateAPIView):
-    permission_classes = (permissions.IsAdminUser,)
+class InventoryReportListCreateView(generics.ListCreateAPIView):
+    permission_classes = (IsAuthenticatedReadOnly | permissions.IsAdminUser,)
     queryset = InventoryReport.objects.all()
     serializer_class = InventoryReportSerializer
-
-
-class InventoryReportListView(generics.ListAPIView):
-    permission_classes = (permissions.IsAuthenticated,)
-    queryset = InventoryReport.objects.all()
-    serializer_class = InventoryReportListSerializer
     pagination_class = ResultSetPagination
 
 
@@ -51,7 +46,43 @@ class InventoryReportRemoveView(generics.DestroyAPIView):
     serializer_class = InventoryReportSerializer
 
 
-class InventorySupplyDetailsUpdateView(generics.RetrieveUpdateAPIView):
-    permission_classes = (permissions.IsAuthenticated,)
-    queryset = InventorySupply.objects.all()
+class InventorySupplyView(generics.RetrieveUpdateAPIView):
     serializer_class = InventorySupplySerializer
+    permission_classes = (permissions.IsAuthenticated,)
+    lookup_url_kwarg = 'supply_id'
+
+    def get(self, request, *args, **kwargs):
+        try:
+            validate_input_data(kwargs)
+            return super().get(request, args, kwargs)
+        except ParameterException as pe:
+            return Response(pe.args[0], status=status.HTTP_400_BAD_REQUEST)
+        except InventoryReport.DoesNotExist:
+            return Response('Report does not exist', status=status.HTTP_404_NOT_FOUND)
+        except InventorySupply.DoesNotExist:
+            return Response('Supply does not exist', status=status.HTTP_404_NOT_FOUND)
+    
+    def patch(self, request, *args, **kwargs):
+        try:
+            validate_input_data(kwargs)
+            return super().patch(request, args, kwargs)
+        except ParameterException as pe:
+            return Response(pe.args[0], status=status.HTTP_400_BAD_REQUEST)
+        except InventoryReport.DoesNotExist:
+            return Response('Report does not exist', status=status.HTTP_404_NOT_FOUND)
+        except InventorySupply.DoesNotExist:
+            return Response('Supply does not exist', status=status.HTTP_404_NOT_FOUND)
+    
+    def put(self, request, *args, **kwargs):
+        try:
+            validate_input_data(kwargs)
+            return super().put(request, args, kwargs)
+        except ParameterException as pe:
+            return Response(pe.args[0], status=status.HTTP_400_BAD_REQUEST)
+        except InventoryReport.DoesNotExist:
+            return Response('Report does not exist', status=status.HTTP_404_NOT_FOUND)
+        except InventorySupply.DoesNotExist:
+            return Response('Supply does not exist', status=status.HTTP_404_NOT_FOUND)
+
+    def get_queryset(self):
+        return InventorySupply.objects.filter(pk=self.kwargs.get('supply_id'))

--- a/backend/supplies/views.py
+++ b/backend/supplies/views.py
@@ -3,7 +3,7 @@ from rest_framework.response import Response
 
 from .models import Supply
 from .serializers import SupplySerializer
-from .permissions import IsAuthenticatedReadOnly
+from backend.permissions import IsAuthenticatedReadOnly
 from backend.pagination import ResultSetPagination
 
 


### PR DESCRIPTION
Changed endpoints:
- **/api/inventories/create** was removed, instead POST method was added to **/api/inventories/**
- **/api/inventories/supplies/{pk}** was removed, instead a new endpoint **/api/inventories/{inventory_id}/supplies/{supply_id}** has been created. It accepts GET, PUT and PATCH methods. Keep in mind that {supply_id} is in fact an ID of inventory supply, not regular supply.

Removal of inventory report stays unchanged, due to the fact that it cannot be simply served at the same endpoint as **/api/inventories/** due to serializers difference.

Tests have been updated to work with the rules above.