### PR TITLE
Fix bug with not refreshing table after clearing print queue.

### DIFF
--- a/frontend/src/Components/Printing/PrintView.js
+++ b/frontend/src/Components/Printing/PrintView.js
@@ -73,7 +73,6 @@ class PrintView extends Component {
                     loading: false,
                     finished: true
                 })
-
             },
             onLoadingStart: () => {
                 this.setState({ loading: true })
@@ -163,8 +162,8 @@ class PrintView extends Component {
         }
     };
 
-    clearQueue() {
-        PrintService.clearQueue()
+    async clearQueue() {
+        await PrintService.clearQueue()
         this.setState({ finished: false })
         this.refreshTable()
     }


### PR DESCRIPTION
Await for clearing queue befor refreshing it.
Issue #100 