### PR TITLE
Hide admin buttons

### DIFF
--- a/backend/users/serializers.py
+++ b/backend/users/serializers.py
@@ -1,7 +1,9 @@
 from rest_framework import serializers
 from .models import User
 
+
 class UserSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
-        fields = ('username', 'email', 'first_name', 'last_name',)
+        fields = ('id', 'username', 'email',
+                  'first_name', 'last_name', 'is_staff')

--- a/backend/users/tests.py
+++ b/backend/users/tests.py
@@ -78,3 +78,28 @@ class UserTests(APITestCase):
         response = UserListView.as_view()(request)
 
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_get_current_user_authenticated(self):
+        """
+        Test getting current user data.
+        Authentication is provided
+        """
+        request = self.factory.get('/api/users/whoami')
+        force_authenticate(request, user=self.testuser)
+        response = UserDetailsView.as_view()(request, pk=self.testuser.pk)
+
+        # compare if response matches with user data
+        for key, value in response.data.items():
+            self.assertEqual(value, vars(request.user)[key])
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_get_current_user_unauthenticated(self):
+        """
+        Test getting current user data.
+        Authentication is not provided
+        """
+        request = self.factory.get('/api/users/current')
+        response = UserDetailsView.as_view()(request, pk=None)
+
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)

--- a/backend/users/urls.py
+++ b/backend/users/urls.py
@@ -1,11 +1,13 @@
 from django.urls import path, include
 from django.conf.urls import url
 
-from .views import UserListView, UserDetailsView
+from .views import UserListView, UserDetailsView, RetrieveCurrentUserView
 
 app_name = "users"
 
 urlpatterns = [
     path('', UserListView.as_view(), name="user-list"),
     path('<pk>/', UserDetailsView.as_view(), name="user-details"),
+    path('whoami', RetrieveCurrentUserView.as_view(),
+         name="current-user-details"),
 ]

--- a/backend/users/views.py
+++ b/backend/users/views.py
@@ -7,15 +7,27 @@ from rest_framework import permissions, generics
 from .models import User
 from .serializers import UserSerializer
 
+
 class UserListView(generics.ListAPIView):
     # Only admin is able to view full list of users
-    permission_classes = [permissions.IsAuthenticated, permissions.IsAdminUser,]
+    permission_classes = [
+        permissions.IsAuthenticated, permissions.IsAdminUser, ]
     queryset = User.objects.all()
     serializer_class = UserSerializer
 
 
 class UserDetailsView(generics.RetrieveAPIView):
     # User can inspect other users' details
-    permission_classes = [permissions.IsAuthenticated,]
+    permission_classes = [permissions.IsAuthenticated, ]
     queryset = User.objects.all()
     serializer_class = UserSerializer
+
+
+class RetrieveCurrentUserView(generics.RetrieveAPIView):
+    permission_classes = [permissions.IsAuthenticated, ]
+    queryset = User.objects.all()
+    serializer_class = UserSerializer
+
+    def get(self, request, *args, **kwargs):
+        self.kwargs['pk'] = request.user.id
+        return super().get(request, *args, **kwargs)

--- a/frontend/src/Components/Supplies/Supplies.js
+++ b/frontend/src/Components/Supplies/Supplies.js
@@ -14,7 +14,7 @@ import { withSnackbar } from 'notistack';
 import { getItems, deleteItem, searchItems } from '../../services/inventoryService';
 import SearchTool from './SearchTool/SearchTool';
 import ButtonPrintQueue from './ButtonPrintQueue';
-
+import authService from '../../services/authService';
 
 
 class Supplies extends React.Component {
@@ -33,8 +33,22 @@ class Supplies extends React.Component {
             openDialogAdd: false,
             openSnackbar: false,
             snackbarMessage: "",
-            snackbarVariant: "info"
+            snackbarVariant: "info",
+            isAdmin: false,
         };
+    }
+
+    async componentDidMount() {
+        let isAdmin = await authService.isCurrentUserAdmin();
+        this.setState({ isAdmin: isAdmin });
+    }
+
+    displayIfAdmin(template) {
+        if (this.state.isAdmin === true) {
+            return template;
+        } else {
+            return null;
+        }
     }
 
     updateData = ({ searchPhase, pageNumber, itemsPerPage } = {}) => {
@@ -257,12 +271,16 @@ class Supplies extends React.Component {
                 customBodyRender: (value, tableMeta, updateValue) => {
                     return (
                         <React.Fragment>
-                            <ButtonRemoveItem
-                                onClick={() => this.onClickDeleteRow(tableMeta.rowIndex)}
-                            />
-                            <ButtonEditItem
-                                onClick={() => this.onClickEditRow(tableMeta.rowIndex)}
-                            />
+                            {this.displayIfAdmin(
+                                <ButtonRemoveItem
+                                    onClick={() => this.onClickDeleteRow(tableMeta.rowIndex)}
+                                />
+                            )}
+                            {this.displayIfAdmin(
+                                <ButtonEditItem
+                                    onClick={() => this.onClickEditRow(tableMeta.rowIndex)}
+                                />
+                            )}
                             <ButtonAddToPrintQueue
                                 onClick={() => this.onClickPrint(tableMeta.rowIndex)}
                             />
@@ -295,7 +313,7 @@ class Supplies extends React.Component {
 
             customToolbar: () => (
                 <div className={styles.toolbar}>
-                    <ButtonAddItem onClickAddItem={() => this.onClickAddItem()} />
+                    {this.displayIfAdmin(<ButtonAddItem onClickAddItem={() => this.onClickAddItem()} />)}
                     <ButtonPrintQueue onClickPrint={() => this.props.history.push('/printing')} />
                     <SearchTool
                         onOpen={this.onSearchOpen}
@@ -329,6 +347,7 @@ class Supplies extends React.Component {
                     }}
                     onFailure={() => this.showSnackbar("error", "Wystąpił błąd!")}
                 />
+
 
                 <DialogEditItem
                     open={this.state.openDialogEdit}

--- a/frontend/src/services/authService.js
+++ b/frontend/src/services/authService.js
@@ -9,5 +9,13 @@ class authService {
     static registerToken = credentials => {
         return Axios.post('rest-auth/registration/', { username: credentials.username, email: credentials.email, password1: credentials.password1, password2: credentials.password2 });
     }
+
+    static async isCurrentUserAdmin() {
+        try {
+            return (await Axios.get('api/users/current')).is_staff;
+        } catch {
+            return false;
+        }
+    }
 }
 export default authService;


### PR DESCRIPTION
Add endpoint to get current user info at /api/users/whoami.
Render buttons to for admin actions only if current user is admin.

Issue: #104 